### PR TITLE
fix: correct Speech Markdown syntax docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,7 +510,8 @@ The library supports Speech Markdown for easier speech formatting across **all e
 
 ```typescript
 // Use Speech Markdown with any engine
-const markdown = "Hello (pause:500ms) world! This is (emphasis:strong) important.";
+const markdown =
+  "Hello [500ms] world! ++This text is emphasized++ (slowly)[rate:\"slow\"] (high)[pitch:\"high\"] (loudly)[volume:\"loud\"]";
 await tts.speak(markdown, { useSpeechMarkdown: true });
 
 // Speech Markdown works with all engines
@@ -524,11 +525,11 @@ await ttsElevenLabs.speak(markdown, { useSpeechMarkdown: true }); // Converts to
 
 ### Supported Speech Markdown Elements
 
-- `(pause:500ms)` - Pauses/breaks
-- `(emphasis:strong)` - Text emphasis
-- `(rate:slow)` - Speech rate control
-- `(pitch:high)` - Pitch control
-- `(volume:loud)` - Volume control
+- `[500ms]` or `[break:"500ms"]` - Pauses/breaks
+- `++text++` or `+text+` - Text emphasis
+- `(text)[rate:"slow"]` - Speech rate control
+- `(text)[pitch:"high"]` - Pitch control
+- `(text)[volume:"loud"]` - Volume control
 
 ### Engine Compatibility
 

--- a/src/markdown/converter.ts
+++ b/src/markdown/converter.ts
@@ -96,8 +96,8 @@ const defaultConverter = new SpeechMarkdownConverter();
  * This function uses the speechmarkdown-js library to convert Speech Markdown syntax to SSML.
  * The library supports various Speech Markdown features including:
  * - Breaks: [500ms] or [break:"500ms"]
- * - Emphasis: *emphasized text*
- * - Rate, pitch, volume: (rate:slow), (pitch:high), (volume:loud)
+ * - Emphasis: ++emphasized++ or +emphasized+
+ * - Rate, pitch, volume: (text)[rate:"slow"], (text)[pitch:"high"], (text)[volume:"loud"]
  * - And many more (see the speechmarkdown-js documentation)
  *
  * @param markdown Speech Markdown text
@@ -114,8 +114,8 @@ export async function toSSML(markdown: string, platform = "amazon-alexa"): Promi
  * This function checks if the text contains Speech Markdown syntax patterns.
  * It uses regular expressions to detect common Speech Markdown patterns such as:
  * - Breaks: [500ms] or [break:"500ms"]
- * - Emphasis: *emphasized text*
- * - Rate, pitch, volume: (rate:slow), (pitch:high), (volume:loud)
+ * - Emphasis: ++text++ or +text+
+ * - Rate, pitch, volume: (text)[rate:"slow"], (text)[pitch:"high"], (text)[volume:"loud"]
  *
  * @param text Text to check
  * @returns True if the text contains Speech Markdown syntax
@@ -125,7 +125,7 @@ export function isSpeechMarkdown(text: string): boolean {
   // This is a simplified version as the library doesn't provide a direct way to check
   const patterns = [
     /\[\d+m?s\]/, // Breaks: [500ms]
-    /\[break:"\w+"\]/, // Breaks with quotes: [break:"weak"]
+    /\[break:"[^"\]]+"\]/, // Breaks with quotes: [break:"weak"] or [break:"500ms"]
     /\+\+.*?\+\+/, // Strong emphasis: ++text++
     /\+.*?\+/, // Moderate emphasis: +text+
     /~.*?~/, // No emphasis: ~text~


### PR DESCRIPTION
## Summary
- document `[break:"500ms"]` and `+text+` Speech Markdown patterns
- broaden Speech Markdown detection to handle quoted break durations

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm run example:elevenlabs` *(fails: connect ENETUNREACH)*
- `npm run example:polly` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_689d76a21f00832798d7a5fece3087da