### PR TITLE
fix(azure): nest <prosody> inside <voice>, not as direct child of <speak>

### DIFF
--- a/src/__tests__/azure-mstts-namespace.test.ts
+++ b/src/__tests__/azure-mstts-namespace.test.ts
@@ -128,5 +128,26 @@ describe("Azure MSTTS Namespace Handling", () => {
       const xmlnsMatches = result.match(/xmlns="http:\/\/www\.w3\.org\/2001\/10\/synthesis"/g);
       expect(xmlnsMatches?.length).toBe(1);
     });
+
+    it("should nest <prosody> inside <voice>, not as a direct child of <speak>", async () => {
+      // Regression test for: https://github.com/willwade/js-tts-wrapper/issues/38
+      // When rate/pitch/volume are passed as options, <prosody> was placed outside
+      // <voice>, which Azure rejects with:
+      //   "Node [speak] with type [RootSpeak] should not contain node [prosody] with type [Others]"
+      const plainSSML = `<speak>Hello world</speak>`;
+      const options = { rate: "fast", pitch: "high", volume: 80 };
+
+      const result = (client as any).ensureAzureSSMLStructure(plainSSML, "en-US-JennyNeural", options);
+
+      // <prosody> must appear after <voice>, not before it
+      const voiceIndex = result.indexOf("<voice");
+      const prosodyIndex = result.indexOf("<prosody");
+      expect(voiceIndex).toBeGreaterThan(-1);
+      expect(prosodyIndex).toBeGreaterThan(voiceIndex);
+
+      // The structure must be <speak><voice><prosody>...</prosody></voice></speak>
+      expect(result).toMatch(/<voice[^>]*>\s*<prosody[^>]*>/);
+      expect(result).toMatch(/<\/prosody>\s*<\/voice>/);
+    });
   });
 });

--- a/src/engines/azure.ts
+++ b/src/engines/azure.ts
@@ -646,12 +646,22 @@ export class AzureTTSClient extends AbstractTTSClient {
       if (options.volume !== undefined) attrs.push(`volume="${options.volume}%"`);
 
       if (attrs.length > 0) {
-        // Extract content
-        const match = ssml.match(/<speak[^>]*>(.*?)<\/speak>/s);
-        if (match) {
-          const content = match[1];
-          const prosodyContent = `<prosody ${attrs.join(" ")}>${content}</prosody>`;
-          ssml = ssml.replace(content, prosodyContent);
+        // Extract content from inside <voice> if present, otherwise from <speak>.
+        // Prosody must be nested inside <voice>, not as a direct child of <speak>.
+        if (ssml.includes("<voice")) {
+          const match = ssml.match(/<voice[^>]*>(.*?)<\/voice>/s);
+          if (match) {
+            const content = match[1];
+            const prosodyContent = `<prosody ${attrs.join(" ")}>${content}</prosody>`;
+            ssml = ssml.replace(content, prosodyContent);
+          }
+        } else {
+          const match = ssml.match(/<speak[^>]*>(.*?)<\/speak>/s);
+          if (match) {
+            const content = match[1];
+            const prosodyContent = `<prosody ${attrs.join(" ")}>${content}</prosody>`;
+            ssml = ssml.replace(content, prosodyContent);
+          }
         }
       }
     }


### PR DESCRIPTION
## Problem

When `rate`, `pitch`, or `volume` are passed as options to `synthToBytestream` / `synthToBytes`, the generated SSML places `<prosody>` as a direct child of `<speak>` instead of inside `<voice>`:

```xml
<!-- Generated (invalid) -->
<speak ...>
  <prosody rate="fast" pitch="high" volume="80%">
    <voice name="en-US-JennyNeural">Hello world</voice>
  </prosody>
</speak>
```

Azure rejects this with HTTP 500:
> Node [speak] with type [RootSpeak] should not contain node [prosody] with type [Others].

## Root cause

In `ensureAzureSSMLStructure`, the `this.properties` branch (rate/pitch/volume set on the client) correctly extracts content from inside `<voice>`. But the `options` branch (rate/pitch/volume passed per-call) always extracted from inside `<speak>`, so once `<voice>` had been injected earlier in the same method, the prosody ended up wrapping it from the outside.

## Fix

Mirror the `this.properties` branch in the `options` branch: when `<voice>` is present, replace content inside `<voice>`; only fall back to `<speak>` when no `<voice>` element exists.

```xml
<!-- Generated after fix (valid) -->
<speak ...>
  <voice name="en-US-JennyNeural">
    <prosody rate="fast" pitch="high" volume="80%">Hello world</prosody>
  </voice>
</speak>
```

## Test

Added regression test in `azure-mstts-namespace.test.ts` that asserts `<prosody>` appears after `<voice>` in the output and matches `/<voice[^>]*>\s*<prosody[^>]*>/`.

Closes #38