### PR TITLE
fix: remove jest.mock() from root __tests__/ for ESM compatibility

### DIFF
--- a/__tests__/abstract-tts-gender.test.ts
+++ b/__tests__/abstract-tts-gender.test.ts
@@ -2,18 +2,11 @@
  * Tests for AbstractTTSClient.getVoicesByGender() (issue #44)
  */
 
+import { AbstractTTSClient } from "../src/core/abstract-tts";
 import type { UnifiedVoice } from "../src/types";
 
-// Minimal stub so we can instantiate a concrete subclass
-jest.mock("../src/core/abstract-tts", () => {
-  const actual = jest.requireActual("../src/core/abstract-tts");
-  return actual;
-});
-
 // Build a concrete subclass with a fixed voice list
-async function makeClient(voices: UnifiedVoice[]) {
-  const { AbstractTTSClient } = await import("../src/core/abstract-tts");
-
+function makeClient(voices: UnifiedVoice[]) {
   class TestTTSClient extends AbstractTTSClient {
     constructor() {
       super({ lang: "en-US" } as any);
@@ -68,29 +61,29 @@ const VOICES: UnifiedVoice[] = [
 
 describe("AbstractTTSClient.getVoicesByGender()", () => {
   it("returns only Female voices when asked for Female", async () => {
-    const client = await makeClient(VOICES);
-    const result = await (client as any).getVoicesByGender("Female");
+    const client = makeClient(VOICES);
+    const result = await client.getVoicesByGender("Female");
     expect(result).toHaveLength(2);
     expect(result.every((v: UnifiedVoice) => v.gender === "Female")).toBe(true);
   });
 
   it("returns only Male voices when asked for Male", async () => {
-    const client = await makeClient(VOICES);
-    const result = await (client as any).getVoicesByGender("Male");
+    const client = makeClient(VOICES);
+    const result = await client.getVoicesByGender("Male");
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe("voice-male-1");
   });
 
   it("returns only Unknown voices when asked for Unknown", async () => {
-    const client = await makeClient(VOICES);
-    const result = await (client as any).getVoicesByGender("Unknown");
+    const client = makeClient(VOICES);
+    const result = await client.getVoicesByGender("Unknown");
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe("voice-unknown-1");
   });
 
   it("returns an empty array when no voices match the gender", async () => {
-    const client = await makeClient([VOICES[0]]); // only Female
-    const result = await (client as any).getVoicesByGender("Male");
+    const client = makeClient([VOICES[0]]); // only Female
+    const result = await client.getVoicesByGender("Male");
     expect(result).toHaveLength(0);
   });
 });

--- a/__tests__/azure-ssml.test.ts
+++ b/__tests__/azure-ssml.test.ts
@@ -2,21 +2,9 @@
  * Tests for Azure SSML generation correctness (issue #42)
  */
 
+import { jest } from "@jest/globals";
+import { AzureTTSClient } from "../src/engines/azure";
 import * as SSMLUtils from "../src/core/ssml-utils";
-
-// Minimal stub so we can import AzureTTSClient without real credentials
-jest.mock("../src/core/abstract-tts", () => {
-  return {
-    AbstractTTSClient: class {
-      voiceId = "en-US-AriaNeural";
-      lang = "en-US";
-      properties: Record<string, unknown> = { rate: "medium", pitch: "medium", volume: 100 };
-      timings: unknown[] = [];
-      on() {}
-      emit() {}
-    },
-  };
-});
 
 // We test the SSML utilities directly — no network calls needed.
 
@@ -43,7 +31,7 @@ describe("createProsodyTag — volume format", () => {
 });
 
 describe("Azure prepareSSML — no spurious xmlns/version warnings", () => {
-  let warnSpy: jest.SpyInstance;
+  let warnSpy: ReturnType<typeof jest.spyOn>;
 
   beforeEach(() => {
     warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
@@ -54,8 +42,6 @@ describe("Azure prepareSSML — no spurious xmlns/version warnings", () => {
   });
 
   it("does not warn about missing xmlns or version when synthesising plain text", async () => {
-    // Import lazily so mock is in place
-    const { AzureTTSClient } = await import("../src/engines/azure");
     const client = new AzureTTSClient({ subscriptionKey: "key", region: "eastus" });
 
     // Access the private method via type cast

--- a/__tests__/elevenlabs-gender.test.ts
+++ b/__tests__/elevenlabs-gender.test.ts
@@ -3,22 +3,12 @@
  * The bulk voice list response includes labels.gender as "female" / "male"
  */
 
-jest.mock("../src/core/abstract-tts", () => ({
-  AbstractTTSClient: class {
-    voiceId = "some-voice-id";
-    lang = "en-US";
-    properties: Record<string, unknown> = { rate: "medium", pitch: "medium", volume: 100 };
-    timings: unknown[] = [];
-    on() {}
-    emit() {}
-  },
-}));
+import { ElevenLabsTTSClient } from "../src/engines/elevenlabs";
 
 describe("ElevenLabs _mapVoicesToUnified — gender mapping", () => {
   let client: any;
 
-  beforeEach(async () => {
-    const { ElevenLabsTTSClient } = await import("../src/engines/elevenlabs");
+  beforeEach(() => {
     client = new ElevenLabsTTSClient({ apiKey: "fake" });
   });
 

--- a/__tests__/google-gender.test.ts
+++ b/__tests__/google-gender.test.ts
@@ -4,22 +4,12 @@
  * These must map to "Male", "Female", "Unknown" in UnifiedVoice
  */
 
-jest.mock("../src/core/abstract-tts", () => ({
-  AbstractTTSClient: class {
-    voiceId = "en-US-Standard-A";
-    lang = "en-US";
-    properties: Record<string, unknown> = { rate: "medium", pitch: "medium", volume: 100 };
-    timings: unknown[] = [];
-    on() {}
-    emit() {}
-  },
-}));
+import { GoogleTTSClient } from "../src/engines/google";
 
 describe("Google _mapVoicesToUnified — gender casing", () => {
   let client: any;
 
-  beforeEach(async () => {
-    const { GoogleTTSClient } = await import("../src/engines/google");
+  beforeEach(() => {
     client = new GoogleTTSClient({ keyFilename: "fake.json" });
   });
 


### PR DESCRIPTION
Closes #46

## Problem

CI runs Jest with `NODE_OPTIONS=--experimental-vm-modules`. In ESM mode, `jest` is not injected as a global — top-level `jest.mock()` calls throw `ReferenceError: jest is not defined`.

Four tests in root `__tests__/` were affected:
- `azure-ssml.test.ts`
- `abstract-tts-gender.test.ts`
- `google-gender.test.ts`
- `elevenlabs-gender.test.ts`

## Fix

The `jest.mock()` calls were either no-ops (mocking with `requireActual`) or unnecessary (engine clients work fine instantiated with fake credentials, as already demonstrated by `src/__tests__/azure-mstts-namespace.test.ts`). Removed all four top-level mock blocks and replaced with direct static imports.

Added `import { jest } from "@jest/globals"` to `azure-ssml.test.ts` for the `jest.spyOn` call, which is the correct ESM pattern.

## Test plan
- [ ] `NODE_OPTIONS=--experimental-vm-modules npx jest __tests__/azure-ssml __tests__/abstract-tts-gender __tests__/google-gender __tests__/elevenlabs-gender` — all 4 pass in ESM mode
- [ ] `npm test` — no regressions