### PR TITLE
feat: export VoiceUtils from browser bundle

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -42,3 +42,4 @@ export * from "./types";
 export { isBrowser, isNode } from "./utils/environment";
 // Utilities
 export { estimateWordBoundaries } from "./utils/word-timing-estimator";
+export * as VoiceUtils from "./core/voice-utils";


### PR DESCRIPTION
Closes #48

## Summary

Adds `export * as VoiceUtils from "./core/voice-utils"` to `src/browser.ts`.

`voice-utils.ts` is pure utility functions over `UnifiedVoice[]` with no Node.js dependencies — safe for the browser bundle.

## Why

Browser/bundler environments (e.g. Next.js with Turbopack) resolve `js-tts-wrapper` imports in client components to the browser bundle. `VoiceUtils` was only on the main ESM entry, which transitively pulls in `sherpa-onnx-node` native addons and fails to build.

## Test plan
- [ ] `npm run build` — browser bundle builds cleanly
- [ ] `import { VoiceUtils } from 'js-tts-wrapper/browser'` works in a Next.js client component