### PR TITLE
fix: normalize gender field across all TTS engines

### DIFF
--- a/src/core/abstract-tts.ts
+++ b/src/core/abstract-tts.ts
@@ -24,6 +24,14 @@ import * as SSMLUtils from "./ssml-utils";
  * This provides a unified interface for all TTS providers
  */
 export abstract class AbstractTTSClient {
+  protected static normalizeGender(value: unknown): "Male" | "Female" | "Unknown" {
+    if (!value || typeof value !== "string") return "Unknown";
+    const lower = value.toLowerCase();
+    if (lower === "female") return "Female";
+    if (lower === "male") return "Male";
+    return "Unknown";
+  }
+
   /**
    * Currently selected voice ID
    */

--- a/src/engines/azure.ts
+++ b/src/engines/azure.ts
@@ -102,7 +102,7 @@ export class AzureTTSClient extends AbstractTTSClient {
     return rawVoices.map((voice: any) => ({
       id: voice.ShortName,
       name: voice.DisplayName,
-      gender: voice.Gender === "Female" ? "Female" : voice.Gender === "Male" ? "Male" : "Unknown",
+      gender: AbstractTTSClient.normalizeGender(voice.Gender),
       provider: "azure",
       languageCodes: [
         {

--- a/src/engines/cartesia.ts
+++ b/src/engines/cartesia.ts
@@ -257,11 +257,13 @@ export class CartesiaTTSClient extends AbstractTTSClient {
     return rawVoices.map((voice) => ({
       id: voice.id,
       name: voice.name,
-      gender: (voice.description?.toLowerCase().includes("female")
-        ? "Female"
-        : voice.description?.toLowerCase().includes("male")
-          ? "Male"
-          : "Unknown") as "Male" | "Female" | "Unknown",
+      gender: AbstractTTSClient.normalizeGender(
+        voice.description?.toLowerCase().includes("female")
+          ? "female"
+          : voice.description?.toLowerCase().includes("male")
+            ? "male"
+            : "Unknown"
+      ),
       languageCodes: voice.language
         ? [
             {

--- a/src/engines/elevenlabs.ts
+++ b/src/engines/elevenlabs.ts
@@ -871,7 +871,7 @@ export class ElevenLabsTTSClient extends AbstractTTSClient {
     return rawVoices.map((voice) => ({
       id: voice.voice_id,
       name: voice.name,
-      gender: undefined, // ElevenLabs doesn't provide gender
+      gender: AbstractTTSClient.normalizeGender(voice.labels?.gender),
       languageCodes: [
         {
           bcp47: voice.labels?.accent || "en-US",
@@ -914,12 +914,7 @@ export class ElevenLabsTTSClient extends AbstractTTSClient {
       const unifiedVoice: UnifiedVoice = {
         id: voice.voice_id,
         name: voice.name,
-        gender:
-          voice.labels?.gender === "female"
-            ? "Female"
-            : voice.labels?.gender === "male"
-              ? "Male"
-              : "Unknown",
+        gender: AbstractTTSClient.normalizeGender(voice.labels?.gender),
         languageCodes: [
           {
             bcp47: voice.labels?.language || "en-US",

--- a/src/engines/fishaudio.ts
+++ b/src/engines/fishaudio.ts
@@ -169,7 +169,7 @@ export class FishAudioTTSClient extends AbstractTTSClient {
       .map((voice: any) => ({
         id: voice._id || voice.id,
         name: voice.title || voice.name || "Unknown",
-        gender: (voice.gender || "Unknown") as "Male" | "Female" | "Unknown",
+        gender: AbstractTTSClient.normalizeGender(voice.gender),
         languageCodes: voice.languages
           ? voice.languages.map((lang: string) => ({
               bcp47: lang,

--- a/src/engines/google.ts
+++ b/src/engines/google.ts
@@ -413,7 +413,7 @@ export class GoogleTTSClient extends AbstractTTSClient {
     return rawVoices.map((voice: any) => ({
       id: voice.name,
       name: voice.name || "Unknown",
-      gender: voice.ssmlGender?.toLowerCase() || undefined,
+      gender: AbstractTTSClient.normalizeGender(voice.ssmlGender),
       languageCodes: voice.languageCodes,
       provider: "google" as const,
       raw: voice, // Keep the original raw voice data

--- a/src/engines/playht.ts
+++ b/src/engines/playht.ts
@@ -215,7 +215,7 @@ export class PlayHTTTSClient extends AbstractTTSClient {
       unifiedVoices.push({
         id: uniqueId,
         name: voice.name,
-        gender: (voice.gender as "Male" | "Female" | "Unknown") || "Unknown",
+        gender: AbstractTTSClient.normalizeGender(voice.gender),
         provider: "playht",
         languageCodes: [languageCode],
       });

--- a/src/engines/resemble.ts
+++ b/src/engines/resemble.ts
@@ -140,7 +140,7 @@ export class ResembleTTSClient extends AbstractTTSClient {
     return rawVoices.map((voice: any) => ({
       id: voice.uuid || voice.id || voice.voice_uuid,
       name: voice.name || voice.uuid || voice.id,
-      gender: (voice.gender || "Unknown") as "Male" | "Female" | "Unknown",
+      gender: AbstractTTSClient.normalizeGender(voice.gender),
       languageCodes: [
         {
           bcp47: voice.language || "en-US",

--- a/src/engines/sapi.ts
+++ b/src/engines/sapi.ts
@@ -146,7 +146,7 @@ export class SAPITTSClient extends AbstractTTSClient {
       const unifiedVoices: UnifiedVoice[] = voiceData.map((voice) => ({
         id: voice.Id || voice.Name || "unknown",
         name: voice.Name || "Unknown Voice",
-        gender: voice.Gender === "Male" || voice.Gender === "Female" ? voice.Gender : "Unknown",
+        gender: AbstractTTSClient.normalizeGender(voice.Gender),
         provider: "sapi",
         languageCodes: [
           {

--- a/src/engines/sherpaonnx-wasm.ts
+++ b/src/engines/sherpaonnx-wasm.ts
@@ -269,7 +269,7 @@ export class SherpaOnnxWasmTTSClient extends AbstractTTSClient {
             return {
               id: model.id,
               name: model.name,
-              gender: (model.gender || "Unknown") as any,
+              gender: AbstractTTSClient.normalizeGender(model.gender),
               provider: "sherpaonnx-wasm" as const,
               languageCodes: [
                 {
@@ -1693,7 +1693,7 @@ class ModelRepository {
             type: derivedType,
             name: model.name || id,
             language: langCode,
-            gender: "unknown", // Not specified in merged_models.json
+            gender: "Unknown",
             sampleRate: model.sample_rate || 22050,
             url,
             compressed: !!model.compression,
@@ -1767,7 +1767,7 @@ class ModelRepository {
         type: "vits",
         name: "Piper Amy (Medium)",
         language: "en-US",
-        gender: "female",
+        gender: "Female",
         sampleRate: 22050,
         files: {
           model: "model.onnx",

--- a/src/engines/sherpaonnx.ts
+++ b/src/engines/sherpaonnx.ts
@@ -1198,7 +1198,7 @@ export class SherpaOnnxTTSClient extends AbstractTTSClient {
       return {
         id: voice.id,
         name: voice.name,
-        gender: voice.gender as "Male" | "Female" | "Unknown",
+        gender: AbstractTTSClient.normalizeGender(voice.gender),
         provider: "sherpaonnx",
         languageCodes: [languageCode],
       };

--- a/src/engines/watson.ts
+++ b/src/engines/watson.ts
@@ -81,7 +81,7 @@ export class WatsonTTSClient extends AbstractTTSClient {
     return rawVoices.map((voice: any) => ({
       id: voice.name,
       name: voice.name.split("_")[1].replace("V3Voice", ""),
-      gender: voice.gender === "female" ? "Female" : voice.gender === "male" ? "Male" : "Unknown",
+      gender: AbstractTTSClient.normalizeGender(voice.gender),
       provider: "ibm",
       languageCodes: [
         {

--- a/src/engines/witai.ts
+++ b/src/engines/witai.ts
@@ -122,7 +122,7 @@ export class WitAITTSClient extends AbstractTTSClient {
     return rawVoices.map((voice: any) => ({
       id: voice.id,
       name: voice.name,
-      gender: voice.gender === "female" ? "Female" : voice.gender === "male" ? "Male" : "Unknown",
+      gender: AbstractTTSClient.normalizeGender(voice.gender),
       provider: "witai",
       languageCodes: voice.languageCodes.map((locale: string) => {
         const [language, region] = locale.split("-");


### PR DESCRIPTION
Add shared AbstractTTSClient.normalizeGender() helper and use it across all engines to ensure gender is always 'Male', 'Female', or 'Unknown' (PascalCase). Fixes bugs where Google produced lowercase values, ElevenLabs bulk listing always returned undefined, and SherpaONNX-WASM had lowercase hardcoded defaults.