### PR TITLE
Add Gemini Flash TTS engine support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ A JavaScript/TypeScript library that provides a unified API for working with mul
 |--------------|------------|-------------|----------|-------------|
 | `azure` | `AzureTTSClient` | Both | Microsoft Azure Cognitive Services | `@azure/cognitiveservices-speechservices`, `microsoft-cognitiveservices-speech-sdk` |
 | `google` | `GoogleTTSClient` | Both | Google Cloud Text-to-Speech | `@google-cloud/text-to-speech` |
+| `gemini` | `GeminiTTSClient` | Both | Gemini Flash TTS | None (uses fetch API) |
 | `elevenlabs` | `ElevenLabsTTSClient` | Both | ElevenLabs | `node-fetch@2` (Node.js only) |
 | `watson` | `WatsonTTSClient` | Both | IBM Watson | None (uses fetch API) |
 | `openai` | `OpenAITTSClient` | Both | OpenAI | `openai` |
@@ -271,7 +272,7 @@ async function runExample() {
 runExample().catch(console.error);
 ```
 
-The factory supports all engines: `'azure'`, `'google'`, `'polly'`, `'elevenlabs'`, `'openai'`, `'modelslab'`, `'playht'`, `'watson'`, `'witai'`, `'sherpaonnx'`, `'sherpaonnx-wasm'`, `'espeak'`, `'espeak-wasm'`, `'sapi'`, `'cartesia'`, `'deepgram'`, `'hume'`, `'xai'`, `'fishaudio'`, `'mistral'`, `'murf'`, `'unrealspeech'`, `'resemble'`, etc.
+The factory supports all engines: `'azure'`, `'google'`, `'gemini'`, `'polly'`, `'elevenlabs'`, `'openai'`, `'modelslab'`, `'playht'`, `'watson'`, `'witai'`, `'sherpaonnx'`, `'sherpaonnx-wasm'`, `'espeak'`, `'espeak-wasm'`, `'sapi'`, `'cartesia'`, `'deepgram'`, `'hume'`, `'xai'`, `'fishaudio'`, `'mistral'`, `'murf'`, `'unrealspeech'`, `'resemble'`, etc.
 
 ## Core Functionality
 
@@ -492,6 +493,7 @@ The following engines **automatically strip SSML tags** and convert to plain tex
 - **Cartesia** - SSML tags removed; audio tags (`[laugh]`, `[sigh]`, etc.) mapped to `<emotion>` for sonic-3, stripped for others
 - **Deepgram** - SSML tags are removed, plain text is synthesized
 - **Hume** - SSML tags are removed, plain text is synthesized
+- **Gemini** - SSML tags are removed; Gemini audio tags are passed natively
 - **xAI** - SSML tags are removed; audio tags passed natively for grok-tts
 - **Fish Audio** - SSML tags removed; audio tags passed natively for s2-pro
 - **Mistral** - SSML tags are removed, plain text is synthesized
@@ -697,6 +699,7 @@ When disabled, js-tts-wrapper falls back to the lightweight built-in converter (
 | Cartesia | ✅ Converted | → SSML → Plain text |
 | Deepgram | ✅ Converted | → SSML → Plain text |
 | Hume | ✅ Converted | → SSML → Plain text |
+| Gemini | ✅ Converted | → SSML → Plain text |
 | xAI | ✅ Converted | → SSML → Plain text |
 | Fish Audio | ✅ Converted | → SSML → Plain text |
 | Mistral | ✅ Converted | → SSML → Plain text |
@@ -842,6 +845,44 @@ Notes:
 - For true timings, use service account credentials (Node) where the beta client can be used.
 - Environment variable supported by examples/tests: `GOOGLECLOUDTTS_API_KEY`.
 
+### Gemini Flash TTS
+
+Gemini Flash TTS uses the Gemini API, not Google Cloud Text-to-Speech. Configure `GEMINI_API_KEY` or pass `apiKey` directly.
+
+Enable the **Gemini API** (`generativelanguage.googleapis.com`) in your Google Cloud project. Google Cloud Text-to-Speech (`texttospeech.googleapis.com`) is not used by this engine.
+
+#### ESM
+```javascript
+import { GeminiTTSClient } from 'js-tts-wrapper';
+
+const tts = new GeminiTTSClient({
+  apiKey: process.env.GEMINI_API_KEY,
+  model: 'gemini-3.1-flash-tts-preview',
+  voice: 'Kore'
+});
+
+const audio = await tts.synthToBytes('Say cheerfully: Have a wonderful day!');
+```
+
+#### Factory
+```javascript
+import { createTTSClient } from 'js-tts-wrapper';
+
+const tts = createTTSClient('gemini', {
+  apiKey: process.env.GEMINI_API_KEY,
+  voice: 'Puck'
+});
+
+await tts.speak('[excitedly] Hello from Gemini Flash TTS!');
+```
+
+Notes:
+- Supported models: `gemini-3.1-flash-tts-preview` (default) and `gemini-2.5-flash-preview-tts`.
+- Supported voices: Zephyr, Puck, Charon, Kore, Fenrir, Leda, Orus, Aoede, Callirrhoe, Autonoe, Enceladus, Iapetus, Umbriel, Algieba, Despina, Erinome, Algenib, Rasalgethi, Laomedeia, Achernar, Alnilam, Schedar, Gacrux, Pulcherrima, Achird, Zubenelgenubi, Vindemiatrix, Sadachbia, Sadaltager, Sulafat.
+- Gemini TTS does not support SSML; SSML tags are stripped before synthesis.
+- Gemini TTS does not provide true streaming; `synthToBytestream()` wraps the completed audio bytes in a stream.
+- Output is WAV by default. Use `{ format: 'pcm' }` to return raw PCM.
+- Gemini audio tags can be included directly in text, such as `[whispers]`, `[laughs]`, or `[excitedly]`.
 
 ### AWS Polly
 
@@ -1441,6 +1482,7 @@ cd your-project
 # Install specific engine dependencies
 npx js-tts-wrapper@latest run install:azure
 npx js-tts-wrapper@latest run install:google
+npx js-tts-wrapper@latest run install:gemini  # no additional dependencies
 npx js-tts-wrapper@latest run install:polly
 npx js-tts-wrapper@latest run install:openai
 npx js-tts-wrapper@latest run install:sherpaonnx

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -61,6 +61,7 @@ async function installEngine(engine) {
   const engineDeps = {
     azure: ["microsoft-cognitiveservices-speech-sdk"],
     google: ["@google-cloud/text-to-speech"],
+    gemini: [],
     elevenlabs: ["node-fetch@2"],
     playht: ["node-fetch@2"],
     polly: ["@aws-sdk/client-polly"],
@@ -136,6 +137,7 @@ Commands:
 Available engines:
   azure               Microsoft Azure TTS
   google              Google Cloud TTS
+  gemini              Gemini Flash TTS (direct REST, no dependencies)
   elevenlabs          ElevenLabs TTS
   playht              PlayHT TTS
   polly               AWS Polly TTS

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "test:azure": "node run-tts-tests.cjs azure",
     "test:elevenlabs": "node run-tts-tests.cjs elevenlabs",
     "test:google": "node run-tts-tests.cjs google",
+    "test:gemini": "node run-tts-tests.cjs gemini",
     "test:polly": "node run-tts-tests.cjs polly",
     "test:openai": "node run-tts-tests.cjs openai",
     "test:playht": "node run-tts-tests.cjs playht",
@@ -99,6 +100,7 @@
     "install:deps": "echo 'Use npm install js-tts-wrapper[engine] instead. For example: npm install js-tts-wrapper[azure]'",
     "install:azure": "npm install microsoft-cognitiveservices-speech-sdk",
     "install:google": "npm install @google-cloud/text-to-speech",
+    "install:gemini": "echo 'Gemini TTS uses direct REST API calls; no additional dependencies required.'",
     "install:polly": "npm install @aws-sdk/client-polly",
     "install:openai": "npm install openai",
     "install:elevenlabs": "npm install @elevenlabs/elevenlabs-js",
@@ -118,6 +120,7 @@
     "text-to-speech",
     "azure",
     "google",
+    "gemini",
     "polly",
     "elevenlabs",
     "ibm",
@@ -247,6 +250,7 @@
     "google": {
       "@google-cloud/text-to-speech": "^6.4.0"
     },
+    "gemini": {},
     "elevenlabs": {
       "@elevenlabs/elevenlabs-js": "^2.32.0"
     },

--- a/run-tts-tests.cjs
+++ b/run-tts-tests.cjs
@@ -20,7 +20,7 @@ const engineName = process.argv[2];
 
 if (!engineName) {
   console.error('Usage: node run-tts-tests.cjs <engine-name>');
-  console.error('Available engines: azure, google, polly, openai, elevenlabs, playht, upliftai, sherpaonnx, sherpaonnx-wasm, sapi, espeak, system');
+  console.error('Available engines: azure, google, gemini, polly, openai, elevenlabs, playht, upliftai, sherpaonnx, sherpaonnx-wasm, sapi, espeak, system');
   process.exit(1);
 }
 
@@ -28,6 +28,7 @@ if (!engineName) {
 const engineTestPatterns = {
   'azure': 'azure',
   'google': 'google',
+  'gemini': 'gemini',
   'polly': 'polly',
   'openai': 'openai',
   'elevenlabs': 'elevenlabs',

--- a/src/__tests__/gemini.test.ts
+++ b/src/__tests__/gemini.test.ts
@@ -1,0 +1,232 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { GeminiTTSClient } from "../engines/gemini";
+import { createBrowserTTSClient } from "../factory-browser";
+import { createTTSClient } from "../factory";
+
+const originalFetch = globalThis.fetch;
+
+function response(body: any, init: { ok?: boolean; status?: number; statusText?: string } = {}) {
+  return {
+    ok: init.ok ?? true,
+    status: init.status ?? 200,
+    statusText: init.statusText ?? "OK",
+    headers: {} as Headers,
+    body: null as any,
+    json: async () => body,
+    text: async () => (typeof body === "string" ? body : JSON.stringify(body)),
+    arrayBuffer: async () => new ArrayBuffer(0),
+  };
+}
+
+function audioResponse(base64Audio: string) {
+  return response({
+    candidates: [
+      {
+        content: {
+          parts: [
+            {
+              inlineData: {
+                data: base64Audio,
+              },
+            },
+          ],
+        },
+      },
+    ],
+  });
+}
+
+function b64(bytes: number[]): string {
+  return Buffer.from(new Uint8Array(bytes)).toString("base64");
+}
+
+describe("GeminiTTSClient", () => {
+  let client: GeminiTTSClient;
+
+  beforeEach(() => {
+    client = new GeminiTTSClient({ apiKey: "test-api-key" });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  it("initializes with default values", () => {
+    expect(client.getProperty("model")).toBe("gemini-3.1-flash-tts-preview");
+    expect(client.getProperty("voice")).toBe("Kore");
+  });
+
+  it("initializes with custom model and voice", () => {
+    const c = new GeminiTTSClient({
+      apiKey: "test",
+      model: "gemini-2.5-flash-preview-tts",
+      voice: "Puck",
+    });
+
+    expect(c.getProperty("model")).toBe("gemini-2.5-flash-preview-tts");
+    expect(c.getProperty("voice")).toBe("Puck");
+  });
+
+  it("initializes with properties object", () => {
+    const c = new GeminiTTSClient({
+      apiKey: "test",
+      properties: { model: "gemini-2.5-flash-preview-tts", voice: "Zephyr" },
+    });
+
+    expect(c.getProperty("model")).toBe("gemini-2.5-flash-preview-tts");
+    expect(c.getProperty("voice")).toBe("Zephyr");
+  });
+
+  it("initializes with propertiesJson string", () => {
+    const c = new GeminiTTSClient({
+      apiKey: "test",
+      propertiesJson: JSON.stringify({ voice: "Sulafat" }),
+    });
+
+    expect(c.getProperty("voice")).toBe("Sulafat");
+  });
+
+  it("sets and gets model, voice, and baseURL", () => {
+    client.setProperty("model", "gemini-2.5-flash-preview-tts");
+    client.setProperty("voice", "Puck");
+    client.setProperty("baseURL", "https://example.test/v1beta");
+
+    expect(client.getProperty("model")).toBe("gemini-2.5-flash-preview-tts");
+    expect(client.getProperty("voice")).toBe("Puck");
+    expect(client.getProperty("baseURL")).toBe("https://example.test/v1beta");
+  });
+
+  it("requires apiKey credential", () => {
+    expect((client as any).getRequiredCredentials()).toEqual(["apiKey"]);
+  });
+
+  it("returns false for checkCredentials without api key", async () => {
+    expect(await new GeminiTTSClient({}).checkCredentials()).toBe(false);
+  });
+
+  it("checks credentials against model list", async () => {
+    globalThis.fetch = jest.fn(async () =>
+      response({
+        models: [{ name: "models/gemini-3.1-flash-tts-preview" }],
+      })
+    ) as any;
+
+    expect(await client.checkCredentials()).toBe(true);
+  });
+
+  it("gets static voices", async () => {
+    const voices = await client.getVoices();
+
+    expect(voices).toHaveLength(30);
+    expect(voices[0]).toHaveProperty("id", "Zephyr");
+    expect(voices[0]).toHaveProperty("provider", "gemini");
+  });
+
+  it("filters voices by supported languages", async () => {
+    expect((await client.getVoicesByLanguage("en")).length).toBeGreaterThan(0);
+    expect((await client.getVoicesByLanguage("fr")).length).toBeGreaterThan(0);
+  });
+
+  it("creates via node and browser factories", () => {
+    expect(createTTSClient("gemini", { apiKey: "test" })).toBeInstanceOf(GeminiTTSClient);
+    expect(createBrowserTTSClient("gemini", { apiKey: "test" })).toBeInstanceOf(GeminiTTSClient);
+  });
+
+  it("strips SSML while preserving Gemini audio tags", async () => {
+    const result = await (client as any).prepareText(
+      "<speak>Hello <break time=\"500ms\"/> [laughs] world</speak>"
+    );
+
+    expect(result).not.toContain("<speak>");
+    expect(result).not.toContain("<break");
+    expect(result).toContain("[laughs]");
+  });
+
+  it("returns WAV bytes by default and sends the Gemini request shape", async () => {
+    const pcm = b64([0, 0, 1, 0]);
+    globalThis.fetch = jest.fn(async () => audioResponse(pcm)) as any;
+
+    const bytes = await client.synthToBytes("Say cheerfully: Hello", { voice: "Puck" });
+    const request = JSON.parse(((globalThis.fetch as any).mock.calls[0][1] as any).body);
+
+    expect(String.fromCharCode(bytes[0], bytes[1], bytes[2], bytes[3])).toBe("RIFF");
+    expect((globalThis.fetch as any).mock.calls[0][0]).toContain(
+      "/models/gemini-3.1-flash-tts-preview:generateContent"
+    );
+    expect(request.generationConfig.responseModalities).toEqual(["AUDIO"]);
+    expect(
+      request.generationConfig.speechConfig.voiceConfig.prebuiltVoiceConfig.voiceName
+    ).toBe("Puck");
+  });
+
+  it("returns raw PCM when requested", async () => {
+    globalThis.fetch = jest.fn(async () => audioResponse(b64([0, 0, 1, 0]))) as any;
+
+    const bytes = await client.synthToBytes("Hello", { format: "pcm" });
+
+    expect(Array.from(bytes)).toEqual([0, 0, 1, 0]);
+  });
+
+  it("uses selected model in request URL", async () => {
+    globalThis.fetch = jest.fn(async () => audioResponse(b64([0, 0]))) as any;
+
+    await client.synthToBytes("Hello", { model: "gemini-2.5-flash-preview-tts" });
+
+    expect((globalThis.fetch as any).mock.calls[0][0]).toContain(
+      "/models/gemini-2.5-flash-preview-tts:generateContent"
+    );
+  });
+
+  it("throws useful error for HTTP failures", async () => {
+    globalThis.fetch = jest.fn(async () =>
+      response("bad request", { ok: false, status: 400, statusText: "Bad Request" })
+    ) as any;
+
+    await expect(client.synthToBytes("Hello")).rejects.toThrow(
+      "Gemini TTS API error: 400 Bad Request"
+    );
+  });
+
+  it("throws useful error for missing audio data", async () => {
+    globalThis.fetch = jest.fn(async () =>
+      response({
+        candidates: [
+          {
+            finishReason: "STOP",
+            content: { parts: [{ text: "not audio" }] },
+          },
+        ],
+      })
+    ) as any;
+
+    await expect(client.synthToBytes("Hello")).rejects.toThrow(
+      "Gemini TTS response did not include audio data"
+    );
+  });
+
+  it("wraps synthesized bytes in a stream and returns estimated word boundaries", async () => {
+    globalThis.fetch = jest.fn(async () => audioResponse(b64([0, 0, 1, 0]))) as any;
+
+    const result = await client.synthToBytestream("Hello world", { useWordBoundary: true });
+    const reader = result.audioStream.getReader();
+    const chunk = await reader.read();
+
+    expect(chunk.done).toBe(false);
+    expect(chunk.value?.length).toBeGreaterThan(0);
+    expect(result.wordBoundaries).toHaveLength(2);
+  });
+
+  it("provides credential status", async () => {
+    globalThis.fetch = jest.fn(async () =>
+      response({
+        models: [{ name: "models/gemini-3.1-flash-tts-preview" }],
+      })
+    ) as any;
+
+    const status = await client.getCredentialStatus();
+
+    expect(status.engine).toBe("gemini");
+    expect(status.requiresCredentials).toBe(true);
+  });
+});

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -13,6 +13,7 @@ export { DeepgramTTSClient } from "./engines/deepgram";
 export { ElevenLabsTTSClient } from "./engines/elevenlabs";
 export { EspeakBrowserTTSClient } from "./engines/espeak-wasm";
 export { FishAudioTTSClient } from "./engines/fishaudio";
+export { GeminiTTSClient } from "./engines/gemini";
 export { GoogleTTSClient } from "./engines/google";
 export { HumeTTSClient } from "./engines/hume";
 export { MistralTTSClient } from "./engines/mistral";

--- a/src/engines/gemini.ts
+++ b/src/engines/gemini.ts
@@ -1,0 +1,536 @@
+import { AbstractTTSClient } from "../core/abstract-tts";
+import * as SSMLUtils from "../core/ssml-utils";
+import * as SpeechMarkdown from "../markdown/converter";
+import type { SpeakOptions, TTSCredentials, UnifiedVoice } from "../types";
+import { getFetch } from "../utils/fetch-utils";
+import { toIso639_3, toLanguageDisplay } from "../utils/language-utils";
+
+export type GeminiTTSModel = "gemini-3.1-flash-tts-preview" | "gemini-2.5-flash-preview-tts";
+
+export type GeminiTTSVoice =
+  | "Zephyr"
+  | "Puck"
+  | "Charon"
+  | "Kore"
+  | "Fenrir"
+  | "Leda"
+  | "Orus"
+  | "Aoede"
+  | "Callirrhoe"
+  | "Autonoe"
+  | "Enceladus"
+  | "Iapetus"
+  | "Umbriel"
+  | "Algieba"
+  | "Despina"
+  | "Erinome"
+  | "Algenib"
+  | "Rasalgethi"
+  | "Laomedeia"
+  | "Achernar"
+  | "Alnilam"
+  | "Schedar"
+  | "Gacrux"
+  | "Pulcherrima"
+  | "Achird"
+  | "Zubenelgenubi"
+  | "Vindemiatrix"
+  | "Sadachbia"
+  | "Sadaltager"
+  | "Sulafat";
+
+export interface GeminiTTSOptions extends SpeakOptions {
+  model?: GeminiTTSModel | string;
+  voice?: GeminiTTSVoice | string;
+  format?: "wav" | "pcm" | "mp3";
+  providerOptions?: Record<string, unknown>;
+}
+
+export interface GeminiTTSCredentials extends TTSCredentials {
+  apiKey?: string;
+  baseURL?: string;
+  model?: GeminiTTSModel | string;
+  voice?: GeminiTTSVoice | string;
+  properties?: Record<string, unknown> | string;
+  propertiesJson?: string;
+}
+
+type GeminiVoiceInfo = {
+  id: GeminiTTSVoice;
+  name: GeminiTTSVoice;
+  style: string;
+};
+
+const SUPPORTED_LANGUAGES = [
+  "ar",
+  "fil",
+  "bn",
+  "fi",
+  "nl",
+  "gl",
+  "en",
+  "ka",
+  "fr",
+  "el",
+  "de",
+  "gu",
+  "hi",
+  "ht",
+  "id",
+  "he",
+  "it",
+  "hu",
+  "ja",
+  "is",
+  "ko",
+  "jv",
+  "mr",
+  "kn",
+  "pl",
+  "kok",
+  "pt",
+  "lo",
+  "ro",
+  "la",
+  "ru",
+  "lv",
+  "es",
+  "lt",
+  "ta",
+  "lb",
+  "te",
+  "mk",
+  "th",
+  "mai",
+  "tr",
+  "mg",
+  "uk",
+  "ms",
+  "vi",
+  "ml",
+  "af",
+  "mn",
+  "sq",
+  "ne",
+  "am",
+  "nb",
+  "hy",
+  "nn",
+  "az",
+  "or",
+  "eu",
+  "ps",
+  "be",
+  "fa",
+  "bg",
+  "pa",
+  "my",
+  "sr",
+  "ca",
+  "sd",
+  "ceb",
+  "si",
+  "cmn",
+  "sk",
+  "hr",
+  "sl",
+  "cs",
+  "sw",
+  "da",
+  "sv",
+  "et",
+  "ur",
+];
+
+/**
+ * Gemini Flash TTS client.
+ *
+ * Uses the Gemini generateContent REST API directly. Gemini TTS returns PCM audio;
+ * this client wraps it as WAV by default so normal playback and conversion paths work.
+ */
+export class GeminiTTSClient extends AbstractTTSClient {
+  private apiKey: string;
+  private baseUrl: string;
+  private model: string;
+
+  static readonly DEFAULT_MODEL: GeminiTTSModel = "gemini-3.1-flash-tts-preview";
+  static readonly DEFAULT_VOICE: GeminiTTSVoice = "Kore";
+
+  static readonly VOICES: GeminiVoiceInfo[] = [
+    { id: "Zephyr", name: "Zephyr", style: "Bright" },
+    { id: "Puck", name: "Puck", style: "Upbeat" },
+    { id: "Charon", name: "Charon", style: "Informative" },
+    { id: "Kore", name: "Kore", style: "Firm" },
+    { id: "Fenrir", name: "Fenrir", style: "Excitable" },
+    { id: "Leda", name: "Leda", style: "Youthful" },
+    { id: "Orus", name: "Orus", style: "Firm" },
+    { id: "Aoede", name: "Aoede", style: "Breezy" },
+    { id: "Callirrhoe", name: "Callirrhoe", style: "Easy-going" },
+    { id: "Autonoe", name: "Autonoe", style: "Bright" },
+    { id: "Enceladus", name: "Enceladus", style: "Breathy" },
+    { id: "Iapetus", name: "Iapetus", style: "Clear" },
+    { id: "Umbriel", name: "Umbriel", style: "Easy-going" },
+    { id: "Algieba", name: "Algieba", style: "Smooth" },
+    { id: "Despina", name: "Despina", style: "Smooth" },
+    { id: "Erinome", name: "Erinome", style: "Clear" },
+    { id: "Algenib", name: "Algenib", style: "Gravelly" },
+    { id: "Rasalgethi", name: "Rasalgethi", style: "Informative" },
+    { id: "Laomedeia", name: "Laomedeia", style: "Upbeat" },
+    { id: "Achernar", name: "Achernar", style: "Soft" },
+    { id: "Alnilam", name: "Alnilam", style: "Firm" },
+    { id: "Schedar", name: "Schedar", style: "Even" },
+    { id: "Gacrux", name: "Gacrux", style: "Mature" },
+    { id: "Pulcherrima", name: "Pulcherrima", style: "Forward" },
+    { id: "Achird", name: "Achird", style: "Friendly" },
+    { id: "Zubenelgenubi", name: "Zubenelgenubi", style: "Casual" },
+    { id: "Vindemiatrix", name: "Vindemiatrix", style: "Gentle" },
+    { id: "Sadachbia", name: "Sadachbia", style: "Lively" },
+    { id: "Sadaltager", name: "Sadaltager", style: "Knowledgeable" },
+    { id: "Sulafat", name: "Sulafat", style: "Warm" },
+  ];
+
+  constructor(credentials: GeminiTTSCredentials = {}) {
+    super(credentials);
+    this.apiKey = credentials.apiKey || this.getEnv("GEMINI_API_KEY");
+    this.baseUrl = credentials.baseURL || "https://generativelanguage.googleapis.com/v1beta";
+    this.model = credentials.model || GeminiTTSClient.DEFAULT_MODEL;
+    this.voiceId = credentials.voice || GeminiTTSClient.DEFAULT_VOICE;
+    this.sampleRate = 24000;
+    this.capabilities = { browserSupported: true, nodeSupported: true };
+    this._models = [
+      { id: "gemini-3.1-flash-tts-preview", features: ["audio-tags"] },
+      { id: "gemini-2.5-flash-preview-tts", features: ["audio-tags"] },
+    ];
+
+    this.applyCredentialProperties(credentials);
+  }
+
+  private getEnv(name: string): string {
+    if (typeof process !== "undefined" && process.env?.[name]) {
+      return process.env[name] || "";
+    }
+    return "";
+  }
+
+  private applyCredentialProperties(credentials: GeminiTTSCredentials): void {
+    const rawProps =
+      (credentials as any).properties ??
+      (credentials as any).propertiesJson ??
+      (credentials as any).propertiesJSON;
+
+    if (!rawProps) return;
+
+    let parsed: Record<string, unknown> | null = null;
+    if (typeof rawProps === "string") {
+      try {
+        parsed = JSON.parse(rawProps);
+      } catch {
+        return;
+      }
+    } else if (typeof rawProps === "object") {
+      parsed = rawProps as Record<string, unknown>;
+    }
+
+    if (!parsed) return;
+
+    for (const [key, value] of Object.entries(parsed)) {
+      this.setProperty(key, value);
+    }
+  }
+
+  private async prepareText(text: string, options?: GeminiTTSOptions): Promise<string> {
+    let processedText = text;
+
+    if (options?.useSpeechMarkdown && SpeechMarkdown.isSpeechMarkdown(processedText)) {
+      const ssml = await SpeechMarkdown.toSSML(processedText, "w3c");
+      processedText = SSMLUtils.stripSSML(ssml);
+    }
+
+    if (SSMLUtils.isSSML(processedText)) {
+      processedText = SSMLUtils.stripSSML(processedText);
+    }
+
+    return processedText;
+  }
+
+  setModel(model: string): void {
+    this.model = model;
+  }
+
+  setVoice(voiceId: string): void {
+    this.voiceId = voiceId;
+  }
+
+  getProperty(property: string): any {
+    switch (property) {
+      case "model":
+        return this.model;
+      case "voice":
+        return this.voiceId;
+      case "baseURL":
+      case "baseUrl":
+        return this.baseUrl;
+      default:
+        return super.getProperty(property);
+    }
+  }
+
+  setProperty(property: string, value: any): void {
+    switch (property) {
+      case "model":
+        this.setModel(value);
+        break;
+      case "voice":
+        this.setVoice(value);
+        break;
+      case "baseURL":
+      case "baseUrl":
+        this.baseUrl = value;
+        break;
+      default:
+        super.setProperty(property, value);
+        break;
+    }
+  }
+
+  protected getRequiredCredentials(): string[] {
+    return ["apiKey"];
+  }
+
+  async checkCredentials(): Promise<boolean> {
+    if (!this.apiKey) return false;
+
+    try {
+      const response = await getFetch()(`${this.baseUrl}/models`, {
+        method: "GET",
+        headers: {
+          "x-goog-api-key": this.apiKey,
+        },
+      });
+
+      if (!response.ok) return false;
+
+      const json = await response.json().catch(() => null);
+      if (!json || !Array.isArray(json.models)) return true;
+
+      return json.models.some((model: any) => {
+        const name = String(model?.name || model?.id || "");
+        return name === this.model || name === `models/${this.model}`;
+      });
+    } catch {
+      return false;
+    }
+  }
+
+  async checkCredentialsDetailed(): Promise<{
+    success: boolean;
+    error?: string;
+    voiceCount?: number;
+  }> {
+    try {
+      const success = await this.checkCredentials();
+      return success
+        ? { success: true, voiceCount: GeminiTTSClient.VOICES.length }
+        : {
+            success: false,
+            error: this.apiKey ? "Gemini credentials are invalid" : "Missing apiKey",
+          };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  protected async _getVoices(): Promise<any[]> {
+    return GeminiTTSClient.VOICES;
+  }
+
+  protected async _mapVoicesToUnified(rawVoices: any[]): Promise<UnifiedVoice[]> {
+    return rawVoices.map((voice: GeminiVoiceInfo) => ({
+      id: voice.id,
+      name: voice.name,
+      gender: "Unknown",
+      provider: "gemini",
+      languageCodes: SUPPORTED_LANGUAGES.map((language) => ({
+        bcp47: language,
+        iso639_3: toIso639_3(language),
+        display: toLanguageDisplay(language),
+      })),
+      metadata: {
+        style: voice.style,
+      },
+    }));
+  }
+
+  async synthToBytes(text: string, options: GeminiTTSOptions = {}): Promise<Uint8Array> {
+    if (!this.apiKey) {
+      throw new Error("Gemini TTS API key is required. Set apiKey or GEMINI_API_KEY.");
+    }
+
+    const preparedText = await this.prepareText(text, options);
+    const model = options.model || this.model;
+    const voiceName = options.voice || this.voiceId || GeminiTTSClient.DEFAULT_VOICE;
+    const generationConfig = {
+      ...options.providerOptions,
+      responseModalities: ["AUDIO"],
+      speechConfig: {
+        voiceConfig: {
+          prebuiltVoiceConfig: {
+            voiceName,
+          },
+        },
+      },
+    };
+
+    const request = {
+      contents: [
+        {
+          parts: [
+            {
+              text: preparedText,
+            },
+          ],
+        },
+      ],
+      generationConfig,
+      model,
+    };
+
+    const response = await getFetch()(`${this.baseUrl}/models/${model}:generateContent`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-goog-api-key": this.apiKey,
+      },
+      body: JSON.stringify(request),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text().catch(() => "");
+      throw new Error(
+        `Gemini TTS API error: ${response.status} ${response.statusText} - ${errorText}`
+      );
+    }
+
+    const json = await response.json();
+    const pcmBytes = this.extractAudioBytes(json);
+    this._createEstimatedWordTimings(preparedText);
+
+    if (options.format === "pcm") {
+      return pcmBytes;
+    }
+
+    return this.pcm16ToWav(pcmBytes, this.sampleRate, 1);
+  }
+
+  async synthToBytestream(
+    text: string,
+    options: GeminiTTSOptions = {}
+  ): Promise<{
+    audioStream: ReadableStream<Uint8Array>;
+    wordBoundaries: Array<{ text: string; offset: number; duration: number }>;
+  }> {
+    const audioBytes = await this.synthToBytes(text, options);
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(audioBytes);
+        controller.close();
+      },
+    });
+
+    const wordBoundaries = options.useWordBoundary
+      ? this.timings.map(([start, end, word]) => ({
+          text: word,
+          offset: Math.round(start * 10000),
+          duration: Math.round((end - start) * 10000),
+        }))
+      : [];
+
+    return { audioStream: stream, wordBoundaries };
+  }
+
+  private extractAudioBytes(response: any): Uint8Array {
+    const candidates = Array.isArray(response?.candidates) ? response.candidates : [];
+    const textParts: string[] = [];
+
+    for (const candidate of candidates) {
+      const parts = Array.isArray(candidate?.content?.parts) ? candidate.content.parts : [];
+      for (const part of parts) {
+        const inlineData = part?.inlineData || part?.inline_data;
+        if (typeof inlineData?.data === "string" && inlineData.data.length > 0) {
+          return this.base64ToBytes(inlineData.data);
+        }
+        if (typeof part?.text === "string") {
+          textParts.push(part.text);
+        }
+      }
+    }
+
+    const finishReasons = candidates
+      .map((candidate: any) => candidate?.finishReason || candidate?.finish_reason)
+      .filter(Boolean)
+      .join(", ");
+    const details = [
+      finishReasons ? `finish reason: ${finishReasons}` : "",
+      textParts.length ? `text parts: ${textParts.join(" ")}` : "",
+    ]
+      .filter(Boolean)
+      .join("; ");
+    throw new Error(
+      `Gemini TTS response did not include audio data${details ? ` (${details})` : ""}.`
+    );
+  }
+
+  private base64ToBytes(base64: string): Uint8Array {
+    try {
+      if (typeof Buffer !== "undefined" && typeof Buffer.from === "function") {
+        return new Uint8Array(Buffer.from(base64, "base64"));
+      }
+
+      const binary = atob(base64);
+      const bytes = new Uint8Array(binary.length);
+      for (let i = 0; i < binary.length; i++) {
+        bytes[i] = binary.charCodeAt(i);
+      }
+      return bytes;
+    } catch (error) {
+      throw new Error(
+        `Failed to decode Gemini TTS audio data: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+
+  private pcm16ToWav(pcmBytes: Uint8Array, sampleRate = 24000, channels = 1): Uint8Array {
+    const bitsPerSample = 16;
+    const byteRate = (sampleRate * channels * bitsPerSample) / 8;
+    const blockAlign = (channels * bitsPerSample) / 8;
+    const headerSize = 44;
+    const wavBytes = new Uint8Array(headerSize + pcmBytes.length);
+    const view = new DataView(wavBytes.buffer);
+
+    this.writeAscii(wavBytes, 0, "RIFF");
+    view.setUint32(4, 36 + pcmBytes.length, true);
+    this.writeAscii(wavBytes, 8, "WAVE");
+    this.writeAscii(wavBytes, 12, "fmt ");
+    view.setUint32(16, 16, true);
+    view.setUint16(20, 1, true);
+    view.setUint16(22, channels, true);
+    view.setUint32(24, sampleRate, true);
+    view.setUint32(28, byteRate, true);
+    view.setUint16(32, blockAlign, true);
+    view.setUint16(34, bitsPerSample, true);
+    this.writeAscii(wavBytes, 36, "data");
+    view.setUint32(40, pcmBytes.length, true);
+    wavBytes.set(pcmBytes, headerSize);
+
+    return wavBytes;
+  }
+
+  private writeAscii(target: Uint8Array, offset: number, value: string): void {
+    for (let i = 0; i < value.length; i++) {
+      target[offset + i] = value.charCodeAt(i);
+    }
+  }
+}

--- a/src/factory-browser.ts
+++ b/src/factory-browser.ts
@@ -5,6 +5,7 @@ import { DeepgramTTSClient } from "./engines/deepgram.js";
 import { ElevenLabsTTSClient } from "./engines/elevenlabs.js";
 import { EspeakBrowserTTSClient } from "./engines/espeak-wasm.js";
 import { FishAudioTTSClient } from "./engines/fishaudio.js";
+import { GeminiTTSClient } from "./engines/gemini.js";
 import { GoogleTTSClient } from "./engines/google.js";
 import { HumeTTSClient } from "./engines/hume.js";
 import { MistralTTSClient } from "./engines/mistral.js";
@@ -42,6 +43,7 @@ export type SupportedBrowserTTS =
   | "cartesia"
   | "deepgram"
   | "fishaudio"
+  | "gemini"
   | "google"
   | "hume"
   | "mistral"
@@ -112,6 +114,10 @@ export function createBrowserTTSClient(engine: SupportedBrowserTTS, credentials?
     case "fishaudio":
       return applyProperties(
         new FishAudioTTSClient(credentials as import("./engines/fishaudio").FishAudioTTSCredentials)
+      );
+    case "gemini":
+      return applyProperties(
+        new GeminiTTSClient(credentials as import("./engines/gemini").GeminiTTSCredentials)
       );
     case "google":
       return applyProperties(

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -6,6 +6,7 @@ import { ElevenLabsTTSClient } from "./engines/elevenlabs.js";
 import { EspeakTTSClient } from "./engines/espeak.js";
 import { EspeakWasmTTSClient } from "./engines/espeak-wasm.js";
 import { FishAudioTTSClient } from "./engines/fishaudio.js";
+import { GeminiTTSClient } from "./engines/gemini.js";
 import { GoogleTTSClient } from "./engines/google.js";
 import { HumeTTSClient } from "./engines/hume.js";
 import { MistralTTSClient } from "./engines/mistral.js";
@@ -45,6 +46,7 @@ export type SupportedTTS =
   | "cartesia"
   | "deepgram"
   | "fishaudio"
+  | "gemini"
   | "google"
   | "hume"
   | "mistral"
@@ -118,6 +120,10 @@ export function createTTSClient(engine: SupportedTTS, credentials?: TTSCredentia
     case "fishaudio":
       return applyProperties(
         new FishAudioTTSClient(credentials as import("./engines/fishaudio").FishAudioTTSCredentials)
+      );
+    case "gemini":
+      return applyProperties(
+        new GeminiTTSClient(credentials as import("./engines/gemini").GeminiTTSCredentials)
       );
     case "google":
       return applyProperties(

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export { ElevenLabsTTSClient } from "./engines/elevenlabs";
 export { EspeakNodeTTSClient, EspeakTTSClient } from "./engines/espeak";
 export { EspeakBrowserTTSClient, EspeakWasmTTSClient } from "./engines/espeak-wasm";
 export { FishAudioTTSClient } from "./engines/fishaudio";
+export { GeminiTTSClient } from "./engines/gemini";
 export { GoogleTTSClient } from "./engines/google";
 export { HumeTTSClient } from "./engines/hume";
 export { MistralTTSClient } from "./engines/mistral";

--- a/src/types.ts
+++ b/src/types.ts
@@ -122,7 +122,8 @@ export type UnifiedVoice = {
     | "resemble"
     | "unrealspeech"
     | "xai"
-    | "fishaudio";
+    | "fishaudio"
+    | "gemini";
 
   /**
    * Language codes supported by this voice


### PR DESCRIPTION
﻿## Summary

- Adds a new `gemini` engine for Gemini Flash TTS via direct Gemini REST API calls.
- Supports the Flash TTS preview models, static Gemini voice metadata, WAV output by default, and raw PCM via `format: "pcm"`.
- Registers the engine in Node/browser factories, exports, provider types, CLI install help, test runner scripts, and README docs.

Closes #53

## Testing

- `npm run test -- gemini`
- `npm run test`
- `npm run build`
- Manual smoke test in sibling project generated and played `gemini-output.wav` using Gemini Flash TTS.
