### PR TITLE
Fix Gemini provider filtering in voice utilities

### DIFF
--- a/src/__tests__/voice-utils.test.ts
+++ b/src/__tests__/voice-utils.test.ts
@@ -1,0 +1,14 @@
+import { filterByProvider } from "../core/voice-utils";
+import { GeminiTTSClient } from "../engines/gemini";
+
+describe("VoiceUtils", () => {
+  it("filters Gemini unified voices by provider", async () => {
+    const client = new GeminiTTSClient({ apiKey: "test-api-key" });
+    const voices = await client.getVoices();
+
+    const geminiVoices = filterByProvider(voices, "gemini");
+
+    expect(geminiVoices).toHaveLength(voices.length);
+    expect(geminiVoices.every((voice) => voice.provider === "gemini")).toBe(true);
+  });
+});

--- a/src/core/voice-utils.ts
+++ b/src/core/voice-utils.ts
@@ -33,16 +33,7 @@ export function filterByGender(
  */
 export function filterByProvider(
   voices: UnifiedVoice[],
-  provider:
-    | "azure"
-    | "google"
-    | "ibm"
-    | "elevenlabs"
-    | "polly"
-    | "witai"
-    | "playht"
-    | "openai"
-    | "sherpa"
+  provider: UnifiedVoice["provider"]
 ): UnifiedVoice[] {
   return voices.filter((voice) => voice.provider === provider);
 }


### PR DESCRIPTION
## Summary

- Fix `VoiceUtils.filterByProvider()` to use the canonical `UnifiedVoice["provider"]` type instead of a stale hard-coded provider union.
- Add a regression test proving Gemini unified voices can be filtered with `filterByProvider(voices, "gemini")`.

Fixes #59

## Validation

- `npm test -- --runTestsByPath src/__tests__/gemini.test.ts src/__tests__/voice-utils.test.ts --runInBand`
- `npm run build`
- pre-push `npm run lint`
